### PR TITLE
Remove hashtag for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: "# 🐜 Bug Report"
+name: "🐜 Bug Report"
 about: "Create a bug report in ANTS"
 ---
 


### PR DESCRIPTION
Closes #5.

There's a stray hashtag in the title that I noticed when testing the issue templates. This PR removes it.