### PR TITLE
Fix clarification section of documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -9,4 +9,4 @@ about: "Create a documentation request in ANTS"
 <!-- Does a there need to be new documentation added? -->
 
 ## Clarification
-<!-- Is a part of the documenation unclear? What would make it clearer?>
+<!-- Is a part of the documenation unclear? What would make it clearer? -->


### PR DESCRIPTION
Under the clarification section of the documentation issue template, the comment is not correctly closed. Currently if you try and add text below this section, it does not appear in the rendered issue, as it is interpreted as a comment.