### PR TITLE
85 Only linux support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: POSIX :: Linux",
-    "Operating System :: Unix",
+    "License :: OSI Approved :: BSD License",
 ]
 
 [project.scripts]


### PR DESCRIPTION
# Ticket Summary #85
## Author: Harold Dyson

Tested that the clone with this change can be installed into an environment created with the (unchanged) `environment.lock` file, and the core rose stem tests pass.

Cannot conceive of a way this would affect contrib, so contrib rose stem tests have not been run.  Failure mode would surely be failing to install in the env (or, less likely, failure for ANTS to import).To be completed prior to review request **and updated** as required during the review process.

**All developers are reminded to follow the [ancil working practices](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices)**

-----


-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `--group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `--group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the contrib tests, pointing at your branch, with `--group=all` to capture any behaviour changes affecting Science codes.

For contrib tests, the bare minimum that will be accepted is the `--group=unittests,qa` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations.
For example, `--group=orography`, `--group=soil`, `--group=lai` etc. when working on code in those groups. <br> To run every test use `--group=all`.

If your change will alter model evolution, affect other linked ancillary generation processes, or provides a new ancillary capability, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

|**Impact of change**| |
|--- | --- |
| Will this maintain results for ANTS `rose stem --group=all` tests? | **YES** |
| Will this maintain results for contrib `rose stem --group=all` tests? | **YES** |
| If this change adds a new capability, has evidence been supplied to show testing across different ANTS decomposition options (typically 0,1,2 in rose stem)? 'where applicable'' | **NA** |
| If this change adds a new capability, has evidence been supplied to show testing of ancillary generation across different resolutions? e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested | **NA** |
| Has your change significantly impacted required resources (runtime and memory) in existing ancillary generation? | **NO** |
| Does your change alter existing ancils? | **NO** |

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

|**Approvals for this change**| |
| --- | --- |
| Have you got approval from the ANTS core development team for changes to codes in core ANTS? | YES |
| Have you got approval from the relevant [Ancillary Science Owner(s)](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/SteeringGroup/DraftScienceOwners) for this change? | NA |
| Have you got approval from the relevant [Ancillary Workflow Owner(s)](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/SteeringGroup/DraftScienceOwners) for this change? | NA |
| If this is a new ancillary capability, who will become the [Ancil Science Owner](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/SteeringGroup/TermsOfReference#AncilScienceowners) for this change? | NA |

------

|**New functionality further testing**| |
| --- | --- |
| If adding new functionality to existing codes, please confirm that the new code doesn't change results when it is switched off and ''works'' when switched on? | **NA** |
| Has the new functionality had unittests added? | **NA** |
| Has the new functionality been added to and tested in Rose Stem? | **NA** |
| If adding new functionality please confirm that the new code compares across different standard decompositions. | **NA** |
| Have you encountered any failures in your rose-stem output(s)? <br>These tasks **must** succeed for your ticket to pass review. | **NO** |
| Have you remembered to run the <code style check tasks/tools> | **YES** |


<div>
Add details of any further testing here.
</div>

------

|**Other**| |
| --- | --- |
| For non-Met Office staff, have you signed and returned the [Contributor Licence Agreement](https://code.metoffice.gov.uk/doc/ancil/ants/latest/appendixB_CLA.html)? | **NA** |
| Are the ticket components, keywords, etc. correct? | **YES** |
| Have links to all linked tickets been provided in the ticket description? | **NA** |
| Have you <requested a code reviewer>? | **YES** |
| Has source data for rose stem been added or changed?  If so, does the licence for the source data allow us to store derived works as sources and KGOs in the repository?  Please include a link to the licence.  | **NO** |
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://code.metoffice.gov.uk/doc/ancil/ants/latest/appendixB_CLA.html)). | Harold Dyson |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#LicencecopyrightandIPR), including appropriate [attribution for usage of Generative AI](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#AIassistanceandattribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | Harold Dyson |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `rose stem --group=all` to help ensure all affected configurations has been flagged up.

<div>
Add trac_status.log contents for ANTS rose-stem here.

(Note: flow.cylc change here is to use a custom module to load the created environment).
Thu  4 Dec 11:54:12 GMT 2025
Git status: 
[
  " M flow.cylc"
]
Commit: 
7131c83e765fb762c2cab5e57c543db0ed40d4f6
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split0 | succeeded | 
 | flake8 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split0 | succeeded | 
 | isort | succeeded | 
 | unittests | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split2 | succeeded | 
 | ancil_2anc_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_create_ite_shapefile | succeeded | 
 | ancil_fill_n_merge_invert_mask_latitude_weighted_kdtree | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_2anc_split0 | succeeded | 
 | black | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split0 | succeeded | 
 | ancil_2anc_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_kdtree | succeeded | 
 | build_docs | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_spiral | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split1 | succeeded | 
 | ancil_fill_n_merge_land_cover_kdtree | succeeded | 
 | ancil_fill_n_merge_land_cover_spiral | succeeded | 
 | ancil_fill_n_merge_land_cover_latitude_weighted_kdtree | succeeded | 
 | rose_ana_2anc | succeeded | 
 | rose_ana_fill_n_merge | succeeded | 
 | rose_ana_general_regrid | succeeded | 
 | rose_ana_general_regrid_spiral | succeeded | 
 | rose_ana_general_regrid_kdtree | succeeded | 
 | rose_ana_general_regrid_latitude_weighted_kdtree | succeeded | 
 | linkcheck | succeeded | 


</div>
<br>
<div>
Add trac_status.log contents for contrib rose-stem here.

As above, have not run contrib rose stem.

</div>
