### PR TITLE
Update ticket details pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -70,7 +70,7 @@ Add details of any further testing here.
 - [ ] I read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
 - [ ] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there.
 - [ ] The issue labels, milestones, etc. are correct
-- [ ] Links to all related tickets have been provided in the ticket description
+- [ ] Links to all related issues have been provided in the pull request description
 - [ ]  I have requested a code reviewer
 - [ ] Source data has been added or changed - please include a link to the license
 


### PR DESCRIPTION
Closes #103.

- I have removed anything that is only relevant to contrib.
- I have updated the template so the majority are tickboxes, hopefully to streamline the process and make it less cumbersome.
- Some checkboxes will not be checked for every PR, I made it this way as it fit in with the previous template (having N/A options) as well as discouraging anyone from just going down the list and checking them all.
- I've rephrased some of the questions since they are now in checkbox form.
- I've left the ones where you have to sign your name alone, as tick boxes can be filled in by anyone.