### PR TITLE
Enable running unittests under SLURM scheduler

### DIFF
--- a/lib/ants/tests/decomposition/test_decompose.py
+++ b/lib/ants/tests/decomposition/test_decompose.py
@@ -3,6 +3,7 @@
 # This file is part of ANTS and is released under the BSD 3-Clause license.
 # See LICENSE.txt in the root of the repository for full licensing details.
 import copy
+import os
 import unittest.mock as mock
 
 import ants.tests
@@ -22,6 +23,12 @@ class TestAll(ants.tests.TestCase):
         new_config = copy.copy(ants.config.GlobalConfiguration())
         new_config.__init__()
 
+        # Similarly, need to remove slurm_ntasks environment variable (if
+        # present).  Hence, want to preserve original environment to restore
+        # it on test completion:
+        self._original_environment = os.environ.copy()
+        os.environ.pop("SLURM_NTASKS", None)
+
         patch = mock.patch("ants.decomposition.CONFIG", new=new_config)
         self.mock_config = patch.start()
         self.addCleanup(patch.stop)
@@ -37,6 +44,9 @@ class TestAll(ants.tests.TestCase):
         self.addCleanup(patch.stop)
 
         self.cube = ants.tests.stock.geodetic((2, 2), name="source")
+
+    def tearDown(self):
+        os.environ = self._original_environment
 
     @mock.patch("ants.utils.cube.defer_cube")
     def test_default_args(self, *args):

--- a/lib/ants/tests/decomposition/test_integration.py
+++ b/lib/ants/tests/decomposition/test_integration.py
@@ -100,9 +100,18 @@ def _binary_setup():
 
 class Common(object):
     def setUp(self):
+        # Need to remove slurm_ntasks environment variable (if
+        # present).  Hence, want to preserve original environment to restore
+        # it on test completion:
+        self._original_environment = os.environ.copy()
+        os.environ.pop("SLURM_NTASKS", None)
+
         patch = mock.patch("warnings.warn")
         self.mock_warnings = patch.start()
         self.addCleanup(patch.stop)
+
+    def tearDown(self):
+        os.environ = self._original_environment
 
     def _assert_metadata_equal(self, actual_results, expected_results):
         for result, expected in zip(


### PR DESCRIPTION
Closes #123 

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices)**

-----

### Branch

**ANTS rose stem logs** <br>
core_ants_on_spice/run1 <br>

-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `--group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `--group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the contrib tests, pointing at your branch, with `--group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [X] This will maintain results for ANTS `rose stem --group=all` tests
- [X] This will this maintain results for contrib `rose stem --group=all` tests
- [N/A ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested
- [N/A ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [N ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [X] I have approval from the ANTS core development team for these changes

------

**New functionality further testing**

- [N/A] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [N/A] Unittests have been added
- [N/A] Rose stem tests have been added for any new functionality
- [N/A] If adding new functionality please confirm that the new code compares across different standard decompositions.
- [X] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [X] I have remembered to run the code style check tasks/tools


<div>
Add details of any further testing here.
</div>

------

**Other**
- [X] I read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [X] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there.
- [X] The issue labels, milestones, etc. are correct
- [X] Links to all related issues have been provided in the pull request description
- [X]  I have requested a code reviewer
- [N/A] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)). | Harold Dyson |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#LicencecopyrightandIPR), including appropriate [attribution for usage of Generative AI](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#AIassistanceandattribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | Harold Dyson |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `rose stem --group=all` to help ensure all affected configurations has been flagged up.

<div>
Fri 27 Feb 15:38:38 GMT 2026
Git status: 
[
  " M app/unittests/rose-app.conf",
  " M flow.cylc",
  "?? site/"
]
Commit: 
78c145d787959dfcc27d573e5d362603a858c7d2
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_general_regrid_3d_to_3d_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split1 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_latitude_weighted_kdtree | succeeded | 
 | ancil_general_regrid_3d_to_3d_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_fill_n_merge_invert_mask_kdtree | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split2 | succeeded | 
 | unittests | succeeded | 
 | ancil_2anc_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split0 | succeeded | 
 | flake8 | succeeded | 
 | ancil_2anc_split1 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split1 | succeeded | 
 | ancil_2anc_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split0 | succeeded | 
 | build_docs | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split1 | succeeded | 
 | isort | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split0 | succeeded | 
 | black | succeeded | 
 | ancil_create_ite_shapefile | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split0 | succeeded | 
 | ancil_fill_n_merge_invert_mask_spiral | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split1 | succeeded | 
 | ancil_fill_n_merge_land_cover_latitude_weighted_kdtree | succeeded | 
 | ancil_fill_n_merge_land_cover_spiral | succeeded | 
 | ancil_fill_n_merge_land_cover_kdtree | succeeded | 
 | rose_ana_2anc | succeeded | 
 | rose_ana_fill_n_merge | succeeded | 
 | rose_ana_general_regrid | succeeded | 
 | rose_ana_general_regrid_spiral | succeeded | 
 | rose_ana_general_regrid_latitude_weighted_kdtree | succeeded | 
 | rose_ana_general_regrid_kdtree | succeeded | 
 | linkcheck | succeeded | 

</div>
Note that there are local changes to the workflow for that rose stem to run the tests under SLURM to confirm the bug is fixed.  I don't think we want those changes at this time (although it is something to consider in future).

<br>
