### PR TITLE
Fix trac log generator counts table

### DIFF
--- a/rose-stem/bin/shutdown_log_generator.sh
+++ b/rose-stem/bin/shutdown_log_generator.sh
@@ -31,7 +31,7 @@ echo "-----" >> $OUTPUT_STATUS_LOG
 echo "## Test Results - Summary ##" >>$OUTPUT_STATUS_LOG
 echo " | **tasks** | **total** | " >> $OUTPUT_STATUS_LOG
 echo " |:-|:-| " >> $OUTPUT_STATUS_LOG
-sqlite3 -separator " | " $DB_LOCATION "select '', status, count(status), '' from task_states" >> $OUTPUT_STATUS_LOG
+sqlite3 -separator " | " $DB_LOCATION "select '', status, count(status), '' from task_states group by status" >> $OUTPUT_STATUS_LOG
 echo " " >> $OUTPUT_STATUS_LOG
 
 # Generate test status summary table for OUTPUT_STATUS_LOG


### PR DESCRIPTION
**ANTS rose stem logs** <br>

ants_counts/run1

-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `--group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `--group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the `ancillary-file-science` tests, pointing at your branch, with `--group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for ANTS `rose stem --group=all` tests
- [x] This will this maintain results for ancillary-file-science `rose stem --group=all` tests
- [ ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Updates the counts in the logs table.
</div>

----

**Approvals for this change**

- [x] I have approval from the ANTS core development team for these changes

------

**New functionality further testing**

- [ ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [ ] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [ ] If adding new functionality please confirm that the new code compares across different standard decompositions.
- [ ] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [ ] I have remembered to run the code style check tasks/tools


<div>
Checked via running rose-stem with unittests group. Reviewer should construct a failed task and schutdown scenario to their satisfaction.
</div>

------

**Other**
- [x] I read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [ ] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there.
- [ ] The issue labels, milestones, etc. are correct
- [ ] Links to all related issues have been provided in the pull request description
- [x]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)). | **Andrew Clark** |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#LicencecopyrightandIPR), including appropriate [attribution for usage of Generative AI](https://code.metoffice.gov.uk/trac/ancil/wiki/ANTS/WorkingPractices#AIassistanceandattribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | **Andrew Clark** |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `rose stem --group=all` to help ensure all affected configurations has been flagged up.

<div>
Wed  4 Mar 13:54:17 GMT 2026
Git status: 
[
  ""
]
Commit: 
38be5e2dec0c15ae444389a1b8aa105c0202abf9
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 5 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | flake8 | succeeded | 
 | isort | succeeded | 
 | black | succeeded | 
 | unittests | succeeded | 
</div>
<br>
