### PR TITLE
Rename floodfill to flood_fill, deprecating floodfill. 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -289,3 +289,4 @@ Contributor Licence Agreement:
 * Harold Dyson (Met Office)
 * Theo Geddes (Met Office)
 * Andrew Clark (Met Office)
+* Jennifer Hickson (Met Office)

--- a/docs/source/release_notes/4.0.rst
+++ b/docs/source/release_notes/4.0.rst
@@ -1,0 +1,28 @@
+.. include:: /common.txt
+
+*********************
+ANTS 4.0 (? 2026)
+*********************
+
+For a full list of changes see the :milestone:`4.0 release milestone <2>`.
+
+Features
+========
+
+Bugs Fixed
+==========
+
+Deprecations
+============
+- :pr:`143`: ``ants.analysis.floodfill`` has been renamed to
+  ``ants.analysis.flood_fill``; ``ants.analysis.floodfill`` has been deprecated.
+
+Incompatible Changes
+====================
+
+Infrastructure
+==============
+
+Documentation
+=============
+

--- a/docs/source/release_notes/index.rst
+++ b/docs/source/release_notes/index.rst
@@ -4,6 +4,7 @@ Release notes
 .. toctree::
    :maxdepth: 2
 
+   4.0.rst
    3.1.rst
    3.0.rst
    2.2.rst

--- a/lib/ants/analysis/__init__.py
+++ b/lib/ants/analysis/__init__.py
@@ -276,7 +276,7 @@ def floodfill(
     array, seed_point, fill_value, extended_neighbourhood=False, wraparound=False
 ):
     """
-    .. deprecated:: ??
+    .. deprecated:: vn4.0
         Use :func:`ants.analysis.flood_fill` instead.
     """
     warnings.warn(

--- a/lib/ants/analysis/__init__.py
+++ b/lib/ants/analysis/__init__.py
@@ -440,7 +440,7 @@ def find_similar_region(
     """
     Return a set of indices where the connecting neighbours have the same value
 
-    This function is functionaly equivelent :func:`flood fill`, except that
+    This function is functionaly equivelent :func:`flood_fill`, except that
     here the fill locations are returned rather than filled.
 
     Parameters

--- a/lib/ants/analysis/__init__.py
+++ b/lib/ants/analysis/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "merge",
     "standard_deviation",
     "floodfill",
+    "flood_fill"
     "find_similar_region",
     "make_consistent_with_lsm",
     "horizontal_grid_reorder",
@@ -247,7 +248,7 @@ def merge(primary_cube, alternate_cube, validity_polygon=None):
     return result
 
 
-def _floodfill_neighbour_identify(
+def _flood_fill_neighbour_identify(
     shape, coords, seed_point, extended_neighbourhood, wraparound
 ):
     (yy, xx) = seed_point
@@ -275,12 +276,27 @@ def floodfill(
     array, seed_point, fill_value, extended_neighbourhood=False, wraparound=False
 ):
     """
-    Floodfill via an iterative algorithm.
+    .. deprecated:: ??
+        Use :func:`ants.analysis.flood_fill` instead.
+    """
+    warnings.warn(
+        "ants.analysis.floodfill has been deprecated. Please use "
+        "ants.analysis.flood_fill instead.",
+        FutureWarning,
+    )
+
+    return flood_fill(array, seed_point, fill_value, extended_neighbourhood, wraparound)
+
+def flood_fill(
+    array, seed_point, fill_value, extended_neighbourhood=False, wraparound=False
+):
+    """
+    Flood fill via an iterative algorithm.
 
     Parameters
     ----------
     array : :class:`~numpy.ndarray`
-        The array to apply the floodfill.
+        The array to apply the flood fill.
     seed_point : tuple
         The starting (y, x) index (the seed point).
     fill_value : int or float
@@ -318,7 +334,7 @@ def floodfill(
         yy, xx = coords.pop()
         if array[yy, xx] == value_at_seed:
             array[yy, xx] = fill_value
-            _floodfill_neighbour_identify(
+            _flood_fill_neighbour_identify(
                 array.shape, coords, (yy, xx), extended_neighbourhood, wraparound
             )
 
@@ -399,7 +415,7 @@ def find_small_feature_seed_points(
     while candidate_inds:
         seed_point = candidate_inds.pop()
         filled = array.copy()
-        floodfill(filled, seed_point, fill_value, extended_neighbourhood, wraparound)
+        flood_fill(filled, seed_point, fill_value, extended_neighbourhood, wraparound)
 
         filled_inds = np.where(filled == fill_value)
         filled_inds = list(zip(list(filled_inds[0]), list(filled_inds[1])))
@@ -423,7 +439,7 @@ def find_similar_region(
     """
     Return a set of indices where the connecting neighbours have the same value
 
-    This function is functionaly equivelent :func:`floodfill`, except that
+    This function is functionaly equivelent :func:`flood fill`, except that
     here the fill locations are returned rather than filled.
 
     Parameters
@@ -470,7 +486,7 @@ def find_similar_region(
         if not visited[yy, xx] and array[yy, xx] == src_value:
             visited[yy, xx] = True
             indices.add((yy, xx))
-            _floodfill_neighbour_identify(
+            _flood_fill_neighbour_identify(
                 array.shape, coords, (yy, xx), extended_neighbourhood, wraparound
             )
     return tuple([[ind[i] for ind in list(indices)] for i in range(array.ndim)])

--- a/lib/ants/analysis/__init__.py
+++ b/lib/ants/analysis/__init__.py
@@ -56,7 +56,7 @@ __all__ = [
     "merge",
     "standard_deviation",
     "floodfill",
-    "flood_fill"
+    "flood_fill",
     "find_similar_region",
     "make_consistent_with_lsm",
     "horizontal_grid_reorder",
@@ -286,6 +286,7 @@ def floodfill(
     )
 
     return flood_fill(array, seed_point, fill_value, extended_neighbourhood, wraparound)
+
 
 def flood_fill(
     array, seed_point, fill_value, extended_neighbourhood=False, wraparound=False

--- a/lib/ants/exceptions.py
+++ b/lib/ants/exceptions.py
@@ -25,17 +25,17 @@ class NoCoverageError(IndexError):
 
 class FloodfillError(ValueError):
     """
-    Raised where the seed point already has the value being floodfilled.
+    Raised where the seed point already has the value being flood filled.
 
     """
 
     def __init__(self, message):
         """
-        Raised where the seed point already has the value being floodfilled.
+        Raised where the seed point already has the value being flood filled.
 
         Args:
 
-        * Message to explain the seed point already has the value being floodfilled.
+        * Message to explain the seed point already has the value being flood filled.
 
         """
         self.message = message

--- a/lib/ants/tests/analysis/test_floodfill.py
+++ b/lib/ants/tests/analysis/test_floodfill.py
@@ -4,13 +4,13 @@
 # See LICENSE.txt in the root of the repository for full licensing details.
 import ants.tests
 import numpy as np
-from ants.analysis import floodfill
+from ants.analysis import flood_fill, floodfill
 from ants.exceptions import FloodfillError
 
 
 class TestValues(ants.tests.TestCase):
     def testall(self):
-        # Ensure that the array that is returned has the floodfill applied to
+        # Ensure that the array that is returned has the flood fill applied to
         # it.
         array = np.ones((5, 4))
         array[1:3, 1:3] = 10
@@ -18,7 +18,7 @@ class TestValues(ants.tests.TestCase):
         target = array.copy()
         target[target == 10] = 5
 
-        floodfill(array, (2, 2), 5)
+        flood_fill(array, (2, 2), 5)
         self.assertArrayEqual(array, target)
 
     def test_nofill(self):
@@ -28,14 +28,14 @@ class TestValues(ants.tests.TestCase):
         array[2, 2] = 5
         message = "The value at location 2x2 already has this fill value."
         with self.assertRaisesRegex(FloodfillError, message):
-            floodfill(array, (2, 2), 5)
+            flood_fill(array, (2, 2), 5)
 
     def test_1Dfill_error(self):
         # Raise a suitable exception when a 1D array is passed in for filling.
         array = np.ones((5))
         message = "The provided array should be 2D but that provided is 1D"
         with self.assertRaisesRegex(ValueError, message):
-            floodfill(array, (0, 0), 5)
+            flood_fill(array, (0, 0), 5)
 
     def test_no_wrap(self):
         # Ensure that wraparound filling doesn't happen when it shouldn't
@@ -45,7 +45,7 @@ class TestValues(ants.tests.TestCase):
         target = array.copy()
         target[:, 0:2] = 5
 
-        floodfill(array, (0, 0), 5, wraparound=False)
+        flood_fill(array, (0, 0), 5, wraparound=False)
         self.assertArrayEqual(array, target)
 
     def test_wraparound(self):
@@ -56,7 +56,7 @@ class TestValues(ants.tests.TestCase):
         target = np.ones((5, 5)) * 5
         target[:, 2] = 10
 
-        floodfill(array, (0, 0), 5, wraparound=True)
+        flood_fill(array, (0, 0), 5, wraparound=True)
         self.assertArrayEqual(array, target)
 
     def test_non_extended_neighbourhood(self):
@@ -68,7 +68,7 @@ class TestValues(ants.tests.TestCase):
         target = array.copy()
         target[1:3, 1:3] = 5
 
-        floodfill(array, (2, 2), 5, extended_neighbourhood=False)
+        flood_fill(array, (2, 2), 5, extended_neighbourhood=False)
         self.assertArrayEqual(array, target)
 
     def test_extended_neighbourhood(self):
@@ -81,7 +81,7 @@ class TestValues(ants.tests.TestCase):
         target[1:3, 1:3] = 5
         target[0, 0] = 5
 
-        floodfill(array, (2, 2), 5, extended_neighbourhood=True)
+        flood_fill(array, (2, 2), 5, extended_neighbourhood=True)
         self.assertArrayEqual(array, target)
 
     def test_wraparound_extended(self):
@@ -94,5 +94,15 @@ class TestValues(ants.tests.TestCase):
         target[0:2, 0:2] = 5
         target[2, -1] = 5
 
-        floodfill(array, (0, 0), 5, extended_neighbourhood=True, wraparound=True)
+        flood_fill(array, (0, 0), 5, extended_neighbourhood=True, wraparound=True)
         self.assertArrayEqual(array, target)
+
+    def test_deprecation_warning(self):
+        # Test that calling the deprecated function floodfill will raise a
+        # FutureWarning
+        array = np.ones(5)
+        message = "ants.analysis.floodfill has been deprecated. Please use " \
+                  "ants.analysis.flood_fill instead."
+
+        with self.assertRaisesRegex(FutureWarning, message):
+            floodfill(array, (0, 0), 5)

--- a/lib/ants/tests/analysis/test_floodfill.py
+++ b/lib/ants/tests/analysis/test_floodfill.py
@@ -101,8 +101,10 @@ class TestValues(ants.tests.TestCase):
         # Test that calling the deprecated function floodfill will raise a
         # FutureWarning
         array = np.ones(5)
-        message = "ants.analysis.floodfill has been deprecated. Please use " \
-                  "ants.analysis.flood_fill instead."
+        message = (
+            "ants.analysis.floodfill has been deprecated. Please use "
+            "ants.analysis.flood_fill instead."
+        )
 
         with self.assertRaisesRegex(FutureWarning, message):
             floodfill(array, (0, 0), 5)

--- a/lib/ants/utils/cube.py
+++ b/lib/ants/utils/cube.py
@@ -1467,7 +1467,7 @@ def extract_region_by_geometry(cube: iris.cube.Cube, geom: shapely.Polygon):
 
     * The "extraction geometry" is the geometry we use to extract the cube sub region,
       using a buffer of 0.25 * region size
-    * The "containment geometry" is the geometry we use to constrain the floodfill,
+    * The "containment geometry" is the geometry we use to constrain the flood fill,
       using a buffer of 0.2 * region size
 
     Parameters


### PR DESCRIPTION
Closes #109 

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**Related branches (e.g. ancillary-file-science):**<br>
jennyhickson/ancillary-file-science:rename_floodfill MetOffice/ancillary-file-science#50

**ANTS rose stem logs** <br>
ANTS_109/run3 <br>


**ancillary-file-science rose stem logs** <br>
ancil_sci_109/run2 <br>

-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the `ancillary-file-science` tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for ANTS `cylc vip ./rose-stem -z group=all` tests
- [x] This will this maintain results for ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [ ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [x] I have approval from the ANTS core development team for these changes

------

**New functionality further testing**

- [ ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [ ] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [ ] If adding new functionality please confirm that the new code compares across different standard decompositions.
- [ ] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [ ] I have remembered to run the code style check tasks/tools


<div>
Add details of any further testing here.
</div>

------

**Other**
- [x] I have read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [x] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [ ] The issue labels, milestones, etc. are correct
- [ ] Links to all related issues have been provided in the pull request description
- [ ]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)). | Jenny Hickson |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | Jenny Hickson |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

Fri 27 Mar 10:54:11 GMT 2026
Git status: 
[
  "?? ../.idea/"
]
Commit: 
c3a2ee3cb426e3fa73a9ba3ace1f1ac219d8cd44
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | build_docs | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_2anc_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split0 | succeeded | 
 | isort | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_spiral | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split0 | succeeded | 
 | ancil_2anc_split0 | succeeded | 
 | unittests | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split1 | succeeded | 
 | flake8 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split1 | succeeded | 
 | ancil_create_ite_shapefile | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split1 | succeeded | 
 | ancil_fill_n_merge_invert_mask_latitude_weighted_kdtree | succeeded | 
 | ancil_2anc_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split0 | succeeded | 
 | black | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_fill_n_merge_invert_mask_kdtree | succeeded | 
 | ancil_general_regrid_3d_to_3d_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split2 | succeeded | 
 | ancil_fill_n_merge_land_cover_kdtree | succeeded | 
 | ancil_fill_n_merge_land_cover_spiral | succeeded | 
 | ancil_fill_n_merge_land_cover_latitude_weighted_kdtree | succeeded | 
 | rose_ana_2anc | succeeded | 
 | rose_ana_fill_n_merge | succeeded | 
 | rose_ana_general_regrid | succeeded | 
 | rose_ana_general_regrid_kdtree | succeeded | 
 | rose_ana_general_regrid_latitude_weighted_kdtree | succeeded | 
 | rose_ana_general_regrid_spiral | succeeded | 
 | linkcheck | succeeded | 

<br>

Fri 27 Mar 11:09:31 GMT 2026
Git status: 
[
  " M app/install_cold/rose-app.conf",
  "?? ../.idea/"
]
Commit: 
8c4dba9921bd384f0907c6e75e283f060110c57d
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 239 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | isort | succeeded | 
 | ancil_orography_filtered_preproc_gmted_ramp2 | succeeded | 
 | ancil_lct_preproc_igbp_split0 | succeeded | 
 | ancil_orography_unfiltered_preproc_globe30 | succeeded | 
 | topographic_index_unittests | succeeded | 
 | ancil_soil_albedo_split0 | succeeded | 
 | ancil_pop_den | succeeded | 
 | ancil_orographic_formdrag_preproc | succeeded | 
 | ancil_lct_preproc_ite_split2 | succeeded | 
 | canopy_heights_unittests | succeeded | 
 | lai_unittests | succeeded | 
 | ancil_ozone_redistribution_gregorian | succeeded | 
 | ancil_soils_clapp_hornberger_split2 | succeeded | 
 | ancil_canopy_heights_split1 | succeeded | 
 | ancil_river_routing_gc6_split0 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_absorption_lw | succeeded | 
 | soil_roughness_unittests | succeeded | 
 | ancil_model_derived_sst_si_climatology_cmip7_si | succeeded | 
 | sample_unittests | succeeded | 
 | ancil_sst_seaice_preproc_oper_AMM15_UKV | succeeded | 
 | ancil_coastal_distance | succeeded | 
 | ancil_dms_chloro_climatology_dms | succeeded | 
 | ancil_lct_postproc_c4_split0 | succeeded | 
 | ancil_soil_albedo_split1 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_asymmetry_lw | succeeded | 
 | ancil_lct_preproc_igbp_split2 | succeeded | 
 | ancil_prescribed_time_varying_veg_split1 | succeeded | 
 | ancil_sst_seaice_preproc_HadISST | succeeded | 
 | ancil_lct_postproc_c4_split2 | succeeded | 
 | ancil_orographic_wavedrag_preproc_globe30 | succeeded | 
 | ancil_lct_cci_split0 | succeeded | 
 | ozone_redistribution_unittests | succeeded | 
 | ancil_model_derived_sst_si_timeseries_cmip7_si | succeeded | 
 | ancil_dms_chloro_timeseries_chl | succeeded | 
 | black | succeeded | 
 | ancil_pop_den_hyde_preproc | succeeded | 
 | cmip7_utils_unittests | succeeded | 
 | ancil_river_routing_gc6_split2 | succeeded | 
 | ancil_soil_roughness_preproc_split1 | succeeded | 
 | ancil_lct_preproc_cci_split2 | succeeded | 
 | orography_unittests | succeeded | 
 | ancil_river_storage_preproc | succeeded | 
 | ancil_sample_split2 | succeeded | 
 | ancil_ozone_redistribution_360_day | succeeded | 
 | lct_unittests | succeeded | 
 | ancil_topographic_index_preproc | succeeded | 
 | ancil_lai_split0 | succeeded | 
 | soil_dust_unittests | succeeded | 
 | ancil_lct_cci_split1 | succeeded | 
 | pop_den_unittests | succeeded | 
 | ancil_soil_albedo_split2 | succeeded | 
 | ancil_soil_roughness_preproc_split0 | succeeded | 
 | ancil_prescribed_time_varying_veg_split0 | succeeded | 
 | sst_seaice_unittests | succeeded | 
 | ancil_lai_split1 | succeeded | 
 | ancil_soils_clapp_hornberger_split1 | succeeded | 
 | ancil_soil_roughness_split0 | succeeded | 
 | ancil_river_routing_preproc | succeeded | 
 | ancil_lake_depth_preproc | succeeded | 
 | ancil_lct_preproc_cci_split0 | succeeded | 
 | ancil_generate_masks_split2 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_asymmetry_sw | succeeded | 
 | cmip7_dms_chloro_unittests | succeeded | 
 | ancil_coastal_distance_unittests | succeeded | 
 | ancil_lct_cci_split2 | succeeded | 
 | ancil_lct_preproc_ite_split0 | succeeded | 
 | ancil_orography_filtered_preproc_globe30 | succeeded | 
 | prescribed_time_varying_veg_unittests | succeeded | 
 | ancil_dms_chloro_timeseries_dms | succeeded | 
 | ancil_model_derived_sst_si_timeseries_cmip7_sst | succeeded | 
 | ancil_soil_roughness_preproc_split2 | succeeded | 
 | ancil_lct_preproc_cci_split1 | succeeded | 
 | river_storage_unittests | succeeded | 
 | ancil_easy_aerosol_preproc_easy_cdnc | succeeded | 
 | river_routing_unittests | succeeded | 
 | ancil_river_routing_1d_river_coupling_split1 | succeeded | 
 | flake8 | succeeded | 
 | ancil_river_routing_1d_river_coupling_split2 | succeeded | 
 | ancil_river_routing_1d_river_coupling_split0 | succeeded | 
 | ancil_sample_tracemalloc_split1 | succeeded | 
 | ancil_soil_roughness_split1 | succeeded | 
 | ancil_model_derived_sst_si_climatology_cmip7_sst | succeeded | 
 | ancil_generate_masks_split0 | succeeded | 
 | soils_unittests | succeeded | 
 | ancil_sample_tracemalloc_split0 | succeeded | 
 | ancil_sample_split0 | succeeded | 
 | ancil_lct_preproc_igbp_split1 | succeeded | 
 | ancil_soil_roughness_split2 | succeeded | 
 | ancil_prescribed_time_varying_veg_split2 | succeeded | 
 | ancil_canopy_heights_split2 | succeeded | 
 | ancil_generate_masks_split1 | succeeded | 
 | ancil_soils_clapp_hornberger_split0 | succeeded | 
 | ancil_lai_split2 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_absorption_sw | succeeded | 
 | ancil_dms_chloro_climatology_chl | succeeded | 
 | ancil_easy_aerosol_preproc_easy_extinction_sw | succeeded | 
 | ancil_lct_preproc_ite_split1 | succeeded | 
 | ancil_sample_split1 | succeeded | 
 | sst_cmip7_unittests | succeeded | 
 | ancil_sample_tracemalloc_split2 | succeeded | 
 | ancil_river_routing_gc6_split1 | succeeded | 
 | ancil_lct_postproc_c4_split1 | succeeded | 
 | ancil_canopy_heights_split0 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_extinction_lw | succeeded | 
 | ancil_orography_unfiltered_preproc_gmted_ramp2 | succeeded | 
 | ancil_orographic_formdrag_split0 | succeeded | 
 | ancil_orographic_formdrag_split2 | succeeded | 
 | ancil_orographic_formdrag_split1 | succeeded | 
 | ancil_orography_mean_epsilon_value_globe30_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_globe30_split0 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_globe30_split0 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_globe30_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_globe30_split1 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_globe30_split1 | succeeded | 
 | rose_ana_pop_den | succeeded | 
 | rose_ana_model_derived_sst_si_climatology_cmip7_si | succeeded | 
 | rose_ana_dms_chloro_climatology_dms | succeeded | 
 | ancil_sst_seaice_oper_AMM15_UKV_split2 | succeeded | 
 | ancil_sst_seaice_oper_AMM15_UKV_split1 | succeeded | 
 | ancil_sst_seaice_oper_AMM15_UKV_split0 | succeeded | 
 | rose_ana_coastal_distance | succeeded | 
 | rose_ana_soil_albedo | succeeded | 
 | ancil_lct_igbp_split1 | succeeded | 
 | ancil_lct_igbp_split2 | succeeded | 
 | ancil_lct_igbp_split0 | succeeded | 
 | ancil_orography_mean_epsilon_value_gmted_ramp2_split1 | succeeded | 
 | ancil_orography_mean_epsilon_default_gmted_ramp2_split0 | succeeded | 
 | ancil_orography_mean_epsilon_default_gmted_ramp2_split1 | succeeded | 
 | ancil_orography_mean_epsilon_default_gmted_ramp2_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_rotated_pole_LAM_split2 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_rotated_pole_LAM_split1 | succeeded | 
 | rose_ana_orographic_wavedrag_gmted_ramp2 | succeeded | 
 | ancil_orography_mean_epsilon_value_gmted_ramp2_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_gmted_ramp2_split0 | succeeded | 
 | ancil_orography_mean_epsilon_value_rotated_pole_LAM_split0 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split0 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split1 | succeeded | 
 | rose_ana_canopy_heights | succeeded | 
 | ancil_lct_ite_split2 | succeeded | 
 | rose_ana_easy_aerosol_preproc | succeeded | 
 | ancil_soil_dust_split2 | succeeded | 
 | rose_ana_soils | succeeded | 
 | rose_ana_dms_chloro_timeseries_chl | succeeded | 
 | rose_ana_ozone_redistribution | succeeded | 
 | rose_ana_model_derived_sst_si_timeseries_cmip7_si | succeeded | 
 | rose_ana_sample | succeeded | 
 | ancil_river_storage_1d_river_coupling | succeeded | 
 | ancil_river_storage_gc6 | succeeded | 
 | rose_ana_orographic_wavedrag_globe30 | succeeded | 
 | ancil_topographic_index_split2 | succeeded | 
 | ancil_topographic_index_split0 | succeeded | 
 | ancil_topographic_index_split1 | succeeded | 
 | ancil_soil_roughness_regrid_split1 | succeeded | 
 | rose_ana_prescribed_time_varying_veg | succeeded | 
 | rose_ana_lai | succeeded | 
 | ancil_sst_seaice_HadISST_split0 | succeeded | 
 | ancil_sst_seaice_HadISST_split2 | succeeded | 
 | ancil_sst_seaice_HadISST_split1 | succeeded | 
 | rose_ana_dms_chloro_timeseries_dms | succeeded | 
 | ancil_add_lakes | succeeded | 
 | rose_ana_model_derived_sst_si_timeseries_cmip7_sst | succeeded | 
 | ancil_river_routing_gc4_split0 | succeeded | 
 | ancil_river_routing_gc4_split2 | succeeded | 
 | ancil_river_routing_gc4_split1 | succeeded | 
 | ancil_soil_roughness_regrid_split2 | succeeded | 
 | ancil_soil_roughness_regrid_split0 | succeeded | 
 | rose_ana_lake_depth_preproc | succeeded | 
 | ancil_lct_ite_split1 | succeeded | 
 | ancil_lct_ite_split0 | succeeded | 
 | ancil_soil_dust_split1 | succeeded | 
 | rose_ana_dms_chloro_climatology_chl | succeeded | 
 | rose_ana_model_derived_sst_si_climatology_cmip7_sst | succeeded | 
 | ancil_soil_dust_split0 | succeeded | 
 | rose_ana_soil_dust | succeeded | 
 | ancil_radiation_parameters_split2 | succeeded | 
 | ancil_radiation_parameters_split1 | succeeded | 
 | ancil_orography_slopes_preproc | succeeded | 
 | ancil_radiation_parameters_split0 | succeeded | 
 | move_lct_files_split0 | succeeded | 
 | rose_ana_sst_seaice | succeeded | 
 | rose_ana_orographic_formdrag | succeeded | 
 | rose_ana_sample_tracemalloc | succeeded | 
 | ancil_soil_roughness_postproc_split1 | succeeded | 
 | rose_ana_river_routing | succeeded | 
 | ancil_time_header_postproc | succeeded | 
 | ancil_sst_seaice_postproc | succeeded | 
 | move_lct_files_split2 | succeeded | 
 | ancil_soil_roughness_postproc_split2 | succeeded | 
 | ancil_soil_roughness_postproc_split0 | succeeded | 
 | rose_ana_orography_mean_globe30 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_globe30_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_globe30_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_globe30_split0 | succeeded | 
 | rose_ana_orography_blended_mean_globe30 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_globe30_split1 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_globe30_split2 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_globe30_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_gmted_ramp2_split2 | succeeded | 
 | rose_ana_orography_mean_gmted_ramp2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_45_deg_polar_cutoff_gmted_ramp2_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_gmted_ramp2_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_45_deg_polar_cutoff_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_rotated_pole_LAM_split2 | succeeded | 
 | rose_ana_orography_mean_LAM | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split2 | succeeded | 
 | move_lct_files_split1 | succeeded | 
 | rose_ana_radiation_parameters | succeeded | 
 | rose_ana_orography_slopes_preproc | succeeded | 
 | rose_ana_time_header_postproc | succeeded | 
 | rose_ana_soil_roughness | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_45_deg_polar_cutoff_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_rotated_pole_LAM_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_rotated_pole_LAM_split1 | succeeded | 
 | rose_ana_orography_blended_globe30 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split1 | succeeded | 
 | seaice_field_reordering | succeeded | 
 | rose_ana_orographic_wavedrag_LAM | succeeded | 
 | rose_ana_river_storage | succeeded | 
 | rose_ana_45_deg_polar_cutoff_gmted_ramp2 | succeeded | 
 | rose_ana_orography_blended_gmted_ramp2 | succeeded | 
 | rose_ana_topographic_index | succeeded | 
 | rose_ana_lct_cci_mask_split2 | succeeded | 
 | rose_ana_lct_igbp_mask_split0 | succeeded | 
 | rose_ana_lct_cci_mask_split0 | succeeded | 
 | rose_ana_lct | succeeded | 
 | rose_ana_lct_igbp_mask_split1 | succeeded | 
 | rose_ana_lct_ite_mask_split1 | succeeded | 
 | rose_ana_lct_cci_mask_split1 | succeeded | 
 | rose_ana_lct_ite_mask_split2 | succeeded | 
 | rose_ana_lct_igbp_mask_split2 | succeeded | 
 | rose_ana_masks | succeeded | 
 | rose_ana_lct_ite_mask_split0 | succeeded | 
