### PR TITLE
Allow update_history to update a Cubelist for bulk updates. 

### DIFF
--- a/lib/ants/io/save.py
+++ b/lib/ants/io/save.py
@@ -185,8 +185,7 @@ def netcdf(
 
     if update_history:
         if history_message is not None:
-            for cube in cubes:
-                ants.utils.cube.update_history(cube, history_message)
+            ants.utils.cube.update_history(cubes, history_message)
         else:
             _update_history_cmd(cubes)
 
@@ -295,7 +294,6 @@ def _update_history_cmd(cube):
 
     """
     metadata = ants.config.CONFIG["ants_metadata"]["history"]
-    date = datetime.today().replace(microsecond=0)
     cubes = ants.utils.cube.as_cubelist(cube)
 
     # In some cases it may be desireable to combine data from different processing
@@ -317,8 +315,7 @@ def _update_history_cmd(cube):
         for cc in cubes:
             cc.attributes["history"] = combined_history
 
-    for cc in cubes:
-        items = sys.argv[:]
-        items[0] = os.path.basename(items[0])
-        items.append("({})".format(metadata)) if metadata else None
-        ants.utils.cube.update_history(cc, " ".join(items), date)
+    items = sys.argv[:]
+    items[0] = os.path.basename(items[0])
+    items.append(f"({metadata})") if metadata else None
+    ants.utils.cube.update_history(cubes, " ".join(items))

--- a/lib/ants/io/save.py
+++ b/lib/ants/io/save.py
@@ -23,7 +23,6 @@ specifying ``saver='ukca'`` (see :func:`ants.io.save.ukca_netcdf`).
 import os
 import sys
 import warnings
-from datetime import datetime
 
 import ants.utils.cube
 import iris

--- a/lib/ants/tests/utils/cube/test_update_history.py
+++ b/lib/ants/tests/utils/cube/test_update_history.py
@@ -10,6 +10,8 @@ from ants.utils.cube import update_history
 class TestAll(ants.tests.TestCase):
     def setUp(self):
         self.cube = iris.cube.Cube(0)
+        self.cube2 = iris.cube.Cube(0)
+        self.cubelist = iris.cube.CubeList([self.cube, self.cube2])
         self.isodate_pattern = r"\d{4,4}-\d{2,2}-\d{2,2}T\d{2,2}:\d{2,2}:" r"\d{2,2}: "
 
     def test_no_existing_history(self):
@@ -39,13 +41,11 @@ class TestAll(ants.tests.TestCase):
 
     def test_update_cubelist(self):
         # Pass a cubelist to all be updated
-        cubelist = iris.cube.CubeList([iris.cube.Cube(0), iris.cube.Cube(0)])
-
         msg = "some test string"
         pattern = self.isodate_pattern + msg
-        update_history(cubelist, msg)
-        self.assertRegex(cubelist[0].attributes["history"], pattern)
-        self.assertRegex(cubelist[1].attributes["history"], pattern)
+        update_history(self.cubelist, msg)
+        for cube in self.cubelist:
+            self.assertRegex(cube.attributes["history"], pattern)
 
     def test_deprecation_warning(self):
         # Use date argument to specify a date. A warning

--- a/lib/ants/tests/utils/cube/test_update_history.py
+++ b/lib/ants/tests/utils/cube/test_update_history.py
@@ -37,15 +37,16 @@ class TestAll(ants.tests.TestCase):
         update_history(self.cube, msg, add_date=False)
         self.assertRegex(self.cube.attributes["history"], pattern)
 
-    def test_not_adding_date_and_providing_date(self):
-        # Use both the argument to stop the date being prepended to the history
-        # attribute and the argument to specify the date to add. A warning
-        # should be raised as these two arguments are incompatible.
+    def test_deprecation_warning(self):
+        # Use date argument to specify a date. A warning
+        # should be raised as this argument is deprecated.
         date = "2000-01-01"
         msg = "some test string"
         error_msg = (
-            "Incompatible arguments provided: the date argument is set to "
-            f"{date} and the add_date argument is set to False."
+            "The date option in ants.utils.cube.update_history has been deprecated."
+            "If add_date is true then the current date and time will be used. "
+            "Cubelists can be passed directly to update_history to be updated with an "
+            "identical history attribute."
         )
-        with self.assertRaisesRegex(RuntimeError, error_msg):
-            update_history(self.cube, msg, date=date, add_date=False)
+        with self.assertRaisesRegex(FutureWarning, error_msg):
+            update_history(self.cube, msg, date=date)

--- a/lib/ants/tests/utils/cube/test_update_history.py
+++ b/lib/ants/tests/utils/cube/test_update_history.py
@@ -37,6 +37,16 @@ class TestAll(ants.tests.TestCase):
         update_history(self.cube, msg, add_date=False)
         self.assertRegex(self.cube.attributes["history"], pattern)
 
+    def test_update_cubelist(self):
+        # Pass a cubelist to all be updated
+        cubelist = iris.cube.CubeList([iris.cube.Cube(0), iris.cube.Cube(0)])
+
+        msg = "some test string"
+        pattern = self.isodate_pattern + msg
+        update_history(cubelist, msg)
+        self.assertRegex(cubelist[0].attributes["history"], pattern)
+        self.assertRegex(cubelist[1].attributes["history"], pattern)
+
     def test_deprecation_warning(self):
         # Use date argument to specify a date. A warning
         # should be raised as this argument is deprecated.

--- a/lib/ants/utils/cube.py
+++ b/lib/ants/utils/cube.py
@@ -697,9 +697,6 @@ def update_history(cube, string, date=None, add_date=True):
     add_date : :obj:`bool`, optional
         Boolean to determine whether the date should be prepended to
         the history content string. True by default.
-
-    .. deprecated::
-        date : This option was deprecated at vn4.0
     """
 
     if date:

--- a/lib/ants/utils/cube.py
+++ b/lib/ants/utils/cube.py
@@ -710,7 +710,6 @@ def update_history(cube, string, date=None, add_date=True):
             FutureWarning,
         )
 
-
     cubes = ants.utils.cube.as_cubelist(cube)
 
     if add_date:

--- a/lib/ants/utils/cube.py
+++ b/lib/ants/utils/cube.py
@@ -689,37 +689,42 @@ def update_history(cube, string, date=None, add_date=True):
 
     Parameters
     ----------
-    cube : :class:`~iris.cube.Cube`
-        Cube to modify its history attribute.
+    cube : :class:`~iris.cube.Cube` or :class:`~iris.cube.Cubelist`
+        Cube or Cubelist to modify its history attribute.
+        If Cubelist then all Cubes will be given an identical history update.
     string : str
         Content to populate the history attribute.
-    date : :obj:`datetime.datetime`, optional
-        ISO-format date stamp for the history atribute update.  If not
-        provided, the current date is determined.
     add_date : :obj:`bool`, optional
         Boolean to determine whether the date should be prepended to
         the history content string. True by default.
 
+    date : This option was deprecated at vn4.0.
     """
 
-    if date and not add_date:
-        raise RuntimeError(
-            "Incompatible arguments provided: the date argument is set "
-            f"to {date} and the add_date argument is set to False."
+    if date:
+        warnings.warn(
+            "The date option in ants.utils.cube.update_history has been deprecated."
+            "If add_date is true then the current date and time will be used. "
+            "Cubelists can be passed directly to update_history to be updated with an "
+            "identical history attribute.",
+            FutureWarning,
         )
 
+
+    cubes = ants.utils.cube.as_cubelist(cube)
+
     if add_date:
-        if not date:
-            date = datetime.today()
+        date = datetime.today()
         date = date.replace(microsecond=0)
 
-        history = "{}: {}".format(date.isoformat(), string)
+        history = f"{date.isoformat()}: {string}"
     else:
         history = string
 
-    if "history" in cube.attributes:
-        history = "\n".join([history, cube.attributes["history"]])
-    cube.attributes["history"] = history
+    for cc in cubes:
+        if "history" in cc.attributes:
+            history = "\n".join([history, cc.attributes["history"]])
+        cc.attributes["history"] = history
 
 
 def get_slices(source, ylim, xlim, pad_width=0):

--- a/lib/ants/utils/cube.py
+++ b/lib/ants/utils/cube.py
@@ -689,16 +689,17 @@ def update_history(cube, string, date=None, add_date=True):
 
     Parameters
     ----------
-    cube : :class:`~iris.cube.Cube` or :class:`~iris.cube.Cubelist`
-        Cube or Cubelist to modify its history attribute.
-        If Cubelist then all Cubes will be given an identical history update.
+    cube : :class:`~iris.cube.Cube` or :class:`~iris.cube.CubeList`
+        Cube or CubeList to modify its history attribute.
+        If CubeList then all Cubes will be given an identical history update.
     string : str
         Content to populate the history attribute.
     add_date : :obj:`bool`, optional
         Boolean to determine whether the date should be prepended to
         the history content string. True by default.
 
-    date : This option was deprecated at vn4.0.
+    .. deprecated::
+        date : This option was deprecated at vn4.0
     """
 
     if date:
@@ -710,7 +711,7 @@ def update_history(cube, string, date=None, add_date=True):
             FutureWarning,
         )
 
-    cubes = ants.utils.cube.as_cubelist(cube)
+    cubes = as_cubelist(cube)
 
     if add_date:
         date = datetime.today()
@@ -721,9 +722,10 @@ def update_history(cube, string, date=None, add_date=True):
         history = string
 
     for cc in cubes:
+        cube_history = history
         if "history" in cc.attributes:
-            history = "\n".join([history, cc.attributes["history"]])
-        cc.attributes["history"] = history
+            cube_history = "\n".join([history, cc.attributes["history"]])
+        cc.attributes["history"] = cube_history
 
 
 def get_slices(source, ylim, xlim, pad_width=0):


### PR DESCRIPTION
Closes #94 

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**Related branches (e.g. ancillary-file-science):**<br>
[please link any related branches here]

**ANTS rose stem logs** <br>
[ants_94/run5](https://cylchub/services/cylc-review/cycles/jennifer.hickson/?suite=ants_94%2Frun5) <br>


**ancillary-file-science rose stem logs** <br>
[ancillary_sci_94/run8](https://cylchub/services/cylc-review/cycles/jennifer.hickson/?suite=ancillary_sci_94%2Frun8) <br>

-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the `ancillary-file-science` tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for ANTS `cylc vip ./rose-stem -z group=all` tests
- [x] This will this maintain results for ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [ ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [x] I have approval from the ANTS core development team for these changes

------

**New functionality further testing**

- [x] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [x] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [ ] If adding new functionality please confirm that the new code compares across different standard decompositions.
- [x] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [x] I have remembered to run the code style check tasks/tools


<div>
Add details of any further testing here.
</div>

------

**Other**
- [x] I have read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [ ] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [ ] The issue labels, milestones, etc. are correct
- [x] Links to all related issues have been provided in the pull request description
- [ ]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)). | Jenny Hickson |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | Jenny Hickson |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

<div>
Thu  9 Apr 10:09:48 BST 2026
Git status: 
[
  " M ../lib/ants/utils/cube.py", -> final docstring change hadn't been committed
  "?? ../.idea/"
]
Commit: 
02624bd5ea1b0a382e39613c2e71658c72d423fc
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split0 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_latitude_weighted_kdtree | succeeded | 
 | ancil_2anc_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_spiral | succeeded | 
 | ancil_2anc_split1 | succeeded | 
 | build_docs | succeeded | 
 | ancil_fill_n_merge_invert_mask_kdtree | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split2 | succeeded | 
 | unittests | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split2 | succeeded | 
 | ancil_create_ite_shapefile | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split0 | succeeded | 
 | ancil_2anc_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split0 | succeeded | 
 | flake8 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split1 | succeeded | 
 | isort | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split0 | succeeded | 
 | black | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split0 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split0 | succeeded | 
 | ancil_fill_n_merge_land_cover_spiral | succeeded | 
 | ancil_fill_n_merge_land_cover_kdtree | succeeded | 
 | ancil_fill_n_merge_land_cover_latitude_weighted_kdtree | succeeded | 
 | rose_ana_fill_n_merge | succeeded | 
 | rose_ana_general_regrid_spiral | succeeded | 
 | rose_ana_general_regrid | succeeded | 
 | rose_ana_2anc | succeeded | 
 | rose_ana_general_regrid_kdtree | succeeded | 
 | rose_ana_general_regrid_latitude_weighted_kdtree | succeeded | 
 | linkcheck | succeeded | 

</div>
<br>
<div>
Wed  8 Apr 14:13:33 BST 2026
Git status: 
[
  " M app/install_cold/rose-app.conf",
  "?? ../.idea/"
]
Commit: 
07602ec07e2ff6b3b3a7033fd2219d158bf3daa0
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 239 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_soil_albedo_split2 | succeeded | 
 | ancil_canopy_heights_split2 | succeeded | 
 | ancil_orography_unfiltered_preproc_globe30 | succeeded | 
 | ancil_sample_tracemalloc_split1 | succeeded | 
 | ancil_river_storage_preproc | succeeded | 
 | orography_unittests | succeeded | 
 | ancil_model_derived_sst_si_climatology_cmip7_sst | succeeded | 
 | ancil_coastal_distance | succeeded | 
 | ancil_generate_masks_split1 | succeeded | 
 | ancil_prescribed_time_varying_veg_split0 | succeeded | 
 | ancil_canopy_heights_split1 | succeeded | 
 | ancil_lct_preproc_igbp_split1 | succeeded | 
 | ancil_model_derived_sst_si_timeseries_cmip7_sst | succeeded | 
 | ancil_sst_seaice_preproc_HadISST | succeeded | 
 | ancil_lct_postproc_c4_split1 | succeeded | 
 | ancil_lct_cci_split1 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_asymmetry_sw | succeeded | 
 | ancil_pop_den | succeeded | 
 | topographic_index_unittests | succeeded | 
 | flake8 | succeeded | 
 | sample_unittests | succeeded | 
 | ancil_lai_split2 | succeeded | 
 | ancil_lct_postproc_c4_split0 | succeeded | 
 | ancil_lai_split0 | succeeded | 
 | canopy_heights_unittests | succeeded | 
 | ancil_canopy_heights_split0 | succeeded | 
 | ancil_lct_preproc_igbp_split0 | succeeded | 
 | ancil_dms_chloro_climatology_chl | succeeded | 
 | ancil_lct_preproc_cci_split2 | succeeded | 
 | lai_unittests | succeeded | 
 | ancil_orography_filtered_preproc_globe30 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_extinction_lw | succeeded | 
 | ancil_easy_aerosol_preproc_easy_absorption_lw | succeeded | 
 | cmip7_dms_chloro_unittests | succeeded | 
 | ancil_easy_aerosol_preproc_easy_asymmetry_lw | succeeded | 
 | ancil_sample_tracemalloc_split0 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_absorption_sw | succeeded | 
 | ancil_lct_preproc_ite_split2 | succeeded | 
 | ancil_lct_preproc_cci_split0 | succeeded | 
 | sst_cmip7_unittests | succeeded | 
 | ancil_sample_tracemalloc_split2 | succeeded | 
 | ancil_lct_postproc_c4_split2 | succeeded | 
 | ancil_lct_cci_split0 | succeeded | 
 | sst_seaice_unittests | succeeded | 
 | ancil_lct_preproc_cci_split1 | succeeded | 
 | ancil_river_routing_gc6_split2 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_cdnc | succeeded | 
 | ancil_soil_roughness_preproc_split1 | succeeded | 
 | ancil_river_routing_1d_river_coupling_split1 | succeeded | 
 | ancil_river_routing_preproc | succeeded | 
 | ancil_sample_split1 | succeeded | 
 | ancil_coastal_distance_unittests | succeeded | 
 | ancil_sst_seaice_preproc_oper_AMM15_UKV | succeeded | 
 | ancil_prescribed_time_varying_veg_split2 | succeeded | 
 | ancil_model_derived_sst_si_timeseries_cmip7_si | succeeded | 
 | ancil_model_derived_sst_si_climatology_cmip7_si | succeeded | 
 | ancil_ozone_redistribution_gregorian | succeeded | 
 | ancil_ozone_redistribution_360_day | succeeded | 
 | soil_dust_unittests | succeeded | 
 | ancil_lct_preproc_ite_split0 | succeeded | 
 | ancil_river_routing_1d_river_coupling_split0 | succeeded | 
 | ancil_river_routing_1d_river_coupling_split2 | succeeded | 
 | ancil_sample_split0 | succeeded | 
 | pop_den_unittests | succeeded | 
 | river_storage_unittests | succeeded | 
 | ancil_soils_clapp_hornberger_split1 | succeeded | 
 | ancil_orography_filtered_preproc_gmted_ramp2 | succeeded | 
 | soils_unittests | succeeded | 
 | ancil_dms_chloro_timeseries_chl | succeeded | 
 | river_routing_unittests | succeeded | 
 | ancil_lct_preproc_ite_split1 | succeeded | 
 | black | succeeded | 
 | ancil_soils_clapp_hornberger_split0 | succeeded | 
 | ancil_dms_chloro_climatology_dms | succeeded | 
 | prescribed_time_varying_veg_unittests | succeeded | 
 | ancil_river_routing_gc6_split0 | succeeded | 
 | ancil_lake_depth_preproc | succeeded | 
 | ancil_prescribed_time_varying_veg_split1 | succeeded | 
 | ancil_lct_preproc_igbp_split2 | succeeded | 
 | ancil_lai_split1 | succeeded | 
 | cmip7_utils_unittests | succeeded | 
 | ozone_redistribution_unittests | succeeded | 
 | isort | succeeded | 
 | ancil_soil_roughness_split1 | succeeded | 
 | ancil_pop_den_hyde_preproc | succeeded | 
 | ancil_soil_roughness_split2 | succeeded | 
 | ancil_soil_roughness_split0 | succeeded | 
 | ancil_topographic_index_preproc | succeeded | 
 | ancil_soil_albedo_split1 | succeeded | 
 | ancil_river_routing_gc6_split1 | succeeded | 
 | ancil_soil_roughness_preproc_split2 | succeeded | 
 | lct_unittests | succeeded | 
 | ancil_soil_roughness_preproc_split0 | succeeded | 
 | ancil_generate_masks_split0 | succeeded | 
 | ancil_easy_aerosol_preproc_easy_extinction_sw | succeeded | 
 | ancil_soil_albedo_split0 | succeeded | 
 | ancil_orographic_wavedrag_preproc_globe30 | succeeded | 
 | ancil_soils_clapp_hornberger_split2 | succeeded | 
 | ancil_orographic_formdrag_preproc | succeeded | 
 | ancil_dms_chloro_timeseries_dms | succeeded | 
 | ancil_orography_unfiltered_preproc_gmted_ramp2 | succeeded | 
 | ancil_generate_masks_split2 | succeeded | 
 | ancil_lct_cci_split2 | succeeded | 
 | soil_roughness_unittests | succeeded | 
 | ancil_sample_split2 | succeeded | 
 | ancil_river_storage_1d_river_coupling | succeeded | 
 | ancil_river_storage_gc6 | succeeded | 
 | ancil_lct_igbp_split1 | succeeded | 
 | rose_ana_prescribed_time_varying_veg | succeeded | 
 | rose_ana_coastal_distance | succeeded | 
 | rose_ana_canopy_heights | succeeded | 
 | rose_ana_lai | succeeded | 
 | rose_ana_soil_albedo | succeeded | 
 | ancil_sst_seaice_HadISST_split1 | succeeded | 
 | ancil_sst_seaice_HadISST_split2 | succeeded | 
 | ancil_sst_seaice_HadISST_split0 | succeeded | 
 | rose_ana_easy_aerosol_preproc | succeeded | 
 | ancil_lct_igbp_split2 | succeeded | 
 | ancil_lct_igbp_split0 | succeeded | 
 | rose_ana_dms_chloro_climatology_chl | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_globe30_split0 | succeeded | 
 | ancil_orography_mean_epsilon_value_globe30_split0 | succeeded | 
 | ancil_orography_mean_epsilon_value_globe30_split2 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_globe30_split1 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_globe30_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_globe30_split1 | succeeded | 
 | rose_ana_model_derived_sst_si_timeseries_cmip7_sst | succeeded | 
 | ancil_lct_ite_split2 | succeeded | 
 | rose_ana_pop_den | succeeded | 
 | ancil_add_lakes | succeeded | 
 | rose_ana_model_derived_sst_si_climatology_cmip7_sst | succeeded | 
 | ancil_soil_roughness_regrid_split1 | succeeded | 
 | ancil_river_routing_gc4_split0 | succeeded | 
 | ancil_river_routing_gc4_split1 | succeeded | 
 | ancil_river_routing_gc4_split2 | succeeded | 
 | ancil_sst_seaice_oper_AMM15_UKV_split1 | succeeded | 
 | ancil_sst_seaice_oper_AMM15_UKV_split0 | succeeded | 
 | ancil_sst_seaice_oper_AMM15_UKV_split2 | succeeded | 
 | ancil_lct_ite_split0 | succeeded | 
 | ancil_lct_ite_split1 | succeeded | 
 | rose_ana_dms_chloro_timeseries_chl | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split0 | succeeded | 
 | ancil_orography_mean_epsilon_default_gmted_ramp2_split1 | succeeded | 
 | ancil_orography_mean_epsilon_value_gmted_ramp2_split0 | succeeded | 
 | ancil_orography_mean_epsilon_default_gmted_ramp2_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_rotated_pole_LAM_split0 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split1 | succeeded | 
 | ancil_orography_mean_epsilon_value_rotated_pole_LAM_split1 | succeeded | 
 | rose_ana_orographic_wavedrag_gmted_ramp2 | succeeded | 
 | ancil_orography_mean_epsilon_default_gmted_ramp2_split0 | succeeded | 
 | ancil_orography_mean_epsilon_value_gmted_ramp2_split2 | succeeded | 
 | ancil_orography_mean_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_rotated_pole_LAM_split2 | succeeded | 
 | ancil_orography_mean_epsilon_value_gmted_ramp2_split1 | succeeded | 
 | rose_ana_soils | succeeded | 
 | ancil_soil_dust_split1 | succeeded | 
 | rose_ana_sample | succeeded | 
 | rose_ana_model_derived_sst_si_climatology_cmip7_si | succeeded | 
 | rose_ana_model_derived_sst_si_timeseries_cmip7_si | succeeded | 
 | rose_ana_ozone_redistribution | succeeded | 
 | rose_ana_dms_chloro_climatology_dms | succeeded | 
 | ancil_soil_dust_split0 | succeeded | 
 | rose_ana_lake_depth_preproc | succeeded | 
 | ancil_topographic_index_split1 | succeeded | 
 | ancil_topographic_index_split2 | succeeded | 
 | ancil_topographic_index_split0 | succeeded | 
 | ancil_soil_roughness_regrid_split2 | succeeded | 
 | ancil_soil_roughness_regrid_split0 | succeeded | 
 | rose_ana_orographic_wavedrag_globe30 | succeeded | 
 | rose_ana_dms_chloro_timeseries_dms | succeeded | 
 | ancil_soil_dust_split2 | succeeded | 
 | rose_ana_sample_tracemalloc | succeeded | 
 | ancil_time_header_postproc | succeeded | 
 | ancil_sst_seaice_postproc | succeeded | 
 | move_lct_files_split1 | succeeded | 
 | move_lct_files_split0 | succeeded | 
 | rose_ana_orography_mean_globe30 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_globe30_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_globe30_split2 | succeeded | 
 | rose_ana_orography_blended_mean_globe30 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_globe30_split1 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_globe30_split0 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_globe30_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_globe30_split1 | succeeded | 
 | ancil_orographic_formdrag_split0 | succeeded | 
 | ancil_orographic_formdrag_split2 | succeeded | 
 | ancil_orographic_formdrag_split1 | succeeded | 
 | ancil_radiation_parameters_split2 | succeeded | 
 | ancil_radiation_parameters_split0 | succeeded | 
 | ancil_radiation_parameters_split1 | succeeded | 
 | ancil_orography_slopes_preproc | succeeded | 
 | ancil_soil_roughness_postproc_split1 | succeeded | 
 | rose_ana_river_routing | succeeded | 
 | rose_ana_sst_seaice | succeeded | 
 | rose_ana_soil_dust | succeeded | 
 | ancil_soil_roughness_postproc_split2 | succeeded | 
 | ancil_soil_roughness_postproc_split0 | succeeded | 
 | seaice_field_reordering | succeeded | 
 | rose_ana_orography_blended_globe30 | succeeded | 
 | move_lct_files_split2 | succeeded | 
 | rose_ana_orography_mean_gmted_ramp2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_gmted_ramp2_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_45_deg_polar_cutoff_gmted_ramp2_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_45_deg_polar_cutoff_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_rotated_pole_LAM_split0 | succeeded | 
 | rose_ana_orography_mean_LAM | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_default_45_deg_polar_cutoff_gmted_ramp2_split0 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_rotated_pole_LAM_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_rotated_pole_LAM_split2 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_gmted_ramp2_split1 | succeeded | 
 | ancil_orographic_wavedrag_epsilon_value_gmted_ramp2_split2 | succeeded | 
 | ancil_orographic_wavedrag_blended_max_slope_0p01_max_smooth_1_gmted_ramp2_split0 | succeeded | 
 | rose_ana_time_header_postproc | succeeded | 
 | rose_ana_soil_roughness | succeeded | 
 | rose_ana_river_storage | succeeded | 
 | rose_ana_orographic_formdrag | succeeded | 
 | rose_ana_45_deg_polar_cutoff_gmted_ramp2 | succeeded | 
 | rose_ana_orographic_wavedrag_LAM | succeeded | 
 | rose_ana_orography_blended_gmted_ramp2 | succeeded | 
 | rose_ana_radiation_parameters | succeeded | 
 | rose_ana_orography_slopes_preproc | succeeded | 
 | rose_ana_topographic_index | succeeded | 
 | rose_ana_lct | succeeded | 
 | rose_ana_lct_cci_mask_split2 | succeeded | 
 | rose_ana_lct_ite_mask_split2 | succeeded | 
 | rose_ana_lct_cci_mask_split1 | succeeded | 
 | rose_ana_lct_igbp_mask_split2 | succeeded | 
 | rose_ana_lct_ite_mask_split1 | succeeded | 
 | rose_ana_lct_igbp_mask_split0 | succeeded | 
 | rose_ana_masks | succeeded | 
 | rose_ana_lct_ite_mask_split0 | succeeded | 
 | rose_ana_lct_igbp_mask_split1 | succeeded | 
 | rose_ana_lct_cci_mask_split0 | succeeded | 

</div>
