### PR TITLE
Make linkcheck optional in GitHub actions workflow

### DIFF
--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -36,6 +36,7 @@ jobs:
             - name: Linkcheck
               shell: micromamba-shell {0}
               run: make --directory=docs linkcheck
+              continue-on-error: ${{ github.event_name == "push" }}
 
             - name: Upload pages artifact
               uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/ci-documentation.yml
+++ b/.github/workflows/ci-documentation.yml
@@ -36,7 +36,7 @@ jobs:
             - name: Linkcheck
               shell: micromamba-shell {0}
               run: make --directory=docs linkcheck
-              continue-on-error: ${{ github.event_name == "push" }}
+              continue-on-error: ${{ github.event_name == 'push' }}
 
             - name: Upload pages artifact
               uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
Closes #153

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**Related branches (e.g. ancillary-file-science):**
N/A

**ANTS rose stem logs**
ANTS/run5

**ancillary-file-science rose stem logs**
N/A

-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the `ancillary-file-science` tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for ANTS `cylc vip ./rose-stem -z group=all` tests
- [N/A] This will this maintain results for ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [N/A] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [x] I have approval from the ANTS core development team for these changes

------

**New functionality further testing**

- [ ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [ ] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [ ] If adding new functionality please confirm that the new code compares across different standard decompositions.
- [x] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [ ] I have remembered to run the code style check tasks/tools


<div>
Add details of any further testing here.
</div>

------

**Other**
- [x] I have read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [x] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [x] The issue labels, milestones, etc. are correct
- [x] Links to all related issues have been provided in the pull request description
- [ ]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)). | **Josh Rackham** |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | **Josh Rackham** |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

<div>
Tue  9 Jun 09:30:54 BST 2026
Git status: 
[
  ""
]
Commit: 
1713e094fc2ad7b16521415e4dd37b8315ba4a5f
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split2 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split1 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split0 | succeeded | 
 | ancil_fill_n_merge_invert_mask_kdtree | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_2anc_split0 | succeeded | 
 | ancil_fill_n_merge_invert_mask_spiral | succeeded | 
 | isort | succeeded | 
 | ancil_create_ite_shapefile | succeeded | 
 | ancil_general_regrid_3d_to_3d_split1 | succeeded | 
 | ancil_2anc_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split0 | succeeded | 
 | unittests | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split1 | succeeded | 
 | ancil_2anc_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_latitude_weighted_kdtree | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split1 | succeeded | 
 | black | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split2 | succeeded | 
 | flake8 | succeeded | 
 | build_docs | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_fill_n_merge_land_cover_spiral | succeeded | 
 | ancil_fill_n_merge_land_cover_latitude_weighted_kdtree | succeeded | 
 | ancil_fill_n_merge_land_cover_kdtree | succeeded | 
 | rose_ana_2anc | succeeded | 
 | rose_ana_general_regrid_kdtree | succeeded | 
 | rose_ana_fill_n_merge | succeeded | 
 | rose_ana_general_regrid_spiral | succeeded | 
 | rose_ana_general_regrid_latitude_weighted_kdtree | succeeded | 
 | rose_ana_general_regrid | succeeded | 
 | linkcheck | succeeded | 

</div>
<br>
<div>
Add workflow_status.log contents for ancillary-file-science rose-stem here.
</div>
