### PR TITLE
#171: Allow cubelist with only one history to be saved

### DIFF
--- a/lib/ants/io/save.py
+++ b/lib/ants/io/save.py
@@ -309,7 +309,8 @@ def _update_history_cmd(cube):
     combined_history = []
     if combine_histories:
         for cc in cubes:
-            combined_history.append(cc.attributes["history"])
+            if "history" in cc.attributes:
+                combined_history.append(cc.attributes["history"])
         combined_history = "\n".join(combined_history)
         for cc in cubes:
             cc.attributes["history"] = combined_history

--- a/lib/ants/tests/io/save/test__update_history_cmd.py
+++ b/lib/ants/tests/io/save/test__update_history_cmd.py
@@ -5,6 +5,7 @@
 import ants.io.save as save
 import ants.tests
 import ants.utils
+import iris.cube
 
 
 def test_multiple_cubes_different_history():
@@ -45,3 +46,14 @@ def test_single_cube_append_history():
     save._update_history_cmd(foo)
     assert foo_history in foo.attributes["history"]
     assert foo.attributes["history"] != foo_history
+
+
+def test_one_cube_histoy():
+    """Tests that if only one cube in a CubeList has history, all cubes will get it."""
+    cube1 = ants.tests.stock.geodetic([2, 2])
+    cube1.attributes["history"] = "the history of cube1"
+    cube2 = ants.tests.stock.geodetic([2, 2])
+    cube3 = ants.tests.stock.geodetic([2, 2])
+    cubelist = iris.cube.CubeList([cube1, cube2, cube3])
+    save._update_history_cmd(cubelist)
+    assert cube3.attributes["history"] == cube1.attributes["history"]


### PR DESCRIPTION
Closes #171

To be completed prior to review request **and updated** as required during the review process.

If the answer to an item on the list is not applicable, feel free to replace the checkbox with 'N/A' to give extra clarity.

**All developers are reminded to follow the [ancil working practices](https://metoffice.github.io/ancil-working-practices)**

-----

### Branch

**Related branches (e.g. ancillary-file-science):**<br>
n/a

**ANTS rose stem logs** <br>
dev-ants-core/run132<br>


**ancillary-file-science rose stem logs** <br>
n/a<br>

-----

### Testing

For core ANTS only tests, the bare minimum that will be accepted is the `group=unittests` but many, if not most, changes will need to test other groups to ensure they meet reviewer expectations. In general, it should be possible and is advised to run the `group=all` group prior to review submission as this will catch any consequential issues. **Additionally** you **must** run the `ancillary-file-science` tests, pointing at your branch, with `group=all` to capture any behaviour changes affecting Science codes.

If your change will alter existing science results, you will need to seek appropriate Scientific validation and confirm that the model has been initialised with your new development. Inspecting a change in xconv/pyplot/visualiser of choice is not sufficient to demonstrate the model can be initialised from your file.

------

**Impact of change**

- [x] This will maintain results for ANTS `cylc vip ./rose-stem -z group=all` tests
- [ ] This will this maintain results for ancillary-file-science `cylc vip ./rose-stem -z group=all` tests
- [ ] If this change adds a new capability, evidence has been supplied to show testing of ancillary generation across different resolutions e.g. For global ancillary generation capabilities for use in NWP n1280e is expected to have been tested
- [ ] This change has significantly impacted required resources (runtime and memory) in existing ancillary generation (if yes, give details)
- [ ] This change alters existing ancils

<div>
Add further comments/details for your reviewers here on the impacts of the change......
</div>

----

**Approvals for this change**

- [x] I have approval from the ANTS core development team for these changes

------

**New functionality further testing**

- [ ] If adding new functionality to existing codes, I confirm that the new code doesn't change results when it is switched off and ''works'' when switched on
- [x] Unittests have been added
- [ ] Rose stem tests have been added for any new functionality
- [ ] If adding new functionality please confirm that the new code compares across different standard decompositions.
- [x] I have not encountered any failures in my rose-stem output(s) <br>These tasks **must** succeed for your ticket to pass review.
- [x] I have remembered to run the code style check tasks/tools


<div>
Add details of any further testing here.
</div>

------

**Other**
- [x] I have read the [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)
- [x] I have added my name and affiliation to the [Contributors list](https://github.com/MetOffice/ANTS/blob/main/CONTRIBUTING.rst#code-contributors) if I am not already on there in this PR.
- [x] The issue labels, milestones, etc. are correct
- [ ] Links to all related issues have been provided in the pull request description
- [x]  I have requested a code reviewer
- [ ] Source data has been added or changed - please include a link to the license

| | |
|---|---|
| I confirm that all code is my own and that my contributions are not subject to copyright or license restrictions (see [Contributor Licence Agreement](https://metoffice.github.io/ANTS/contributing.html#contributor-licence-agreement-v1-1)). | **Theo Geddes** |
| I confirm I have not knowingly violated intellectual property rights (IPR) and have taken [sensible measures to prevent doing so](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html), including appropriate [attribution for usage of Generative AI](https://metoffice.github.io/ancil-working-practices/working_practices/developer/licence-attribution.html#ai-assistance-and-attribution). I confirm that this work is my own, and I understand that it is my responsibility to ensure I am not violating others’ IPR.  This includes taking reasonable steps to ensure that all tools used while creating this contribution did not infringe IPR. | **Theo Geddes** |

<div>
Please add any further notes here.  If Generative AI tools have been used, a brief summary (e.g. "Github copilot used to add extra unittests") should be provided.
</div>

--------
### Rose stem logs

Please copy in the contents of your trac_status.log file(s) below (found in the cylc-run directory for your rose stem run) to your rose-stem testing here. **Note**: if your changes lead to a change in answers, you must run `cylc vip ./rose-stem -z group=all` to help ensure all affected configurations has been flagged up.

<div>
Tue 25 Aug 15:40:13 BST 2026
Git status: 
[
  "?? ../ants.tests",
  "?? ../history-test.nc",
  "?? ../import-test.py",
  "?? ../mpi-fix.lock",
  "?? ../new-env.lock",
  "?? ../wildcard1.pp",
  "?? ../wildcard1.pp.license",
  "?? ../wildcard2.pp"
]
Commit: 
5b63333357fe416cbbef4ca7b3617dbd94a54e27
 
-----
## Test Results - Summary ##
 | **tasks** | **total** | 
 |:-|:-| 
 | succeeded | 65 | 
 
## Test Results - Detail ##
 | **task** | **status** | 
 |:-|:-| 
 | install_cold | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split2 | succeeded | 
 | black | succeeded | 
 | ancil_2anc_split0 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split2 | succeeded | 
 | build_docs | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split2 | succeeded | 
 | ancil_create_ite_shapefile | succeeded | 
 | ancil_general_regrid_3d_to_3d_split0 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split0 | succeeded | 
 | ancil_general_regrid_3d_to_3d_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_spiral | succeeded | 
 | ancil_fill_n_merge_invert_mask_latitude_weighted_kdtree | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split0 | succeeded | 
 | unittests | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split1 | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split2 | succeeded | 
 | ancil_general_regrid_grid_to_n48e_namelist_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_kdtree_split0 | succeeded | 
 | ancil_general_regrid_with_time_constraint_spiral_split1 | succeeded | 
 | ancil_2anc_split2 | succeeded | 
 | ancil_general_regrid_grid_to_grid_spiral_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split2 | succeeded | 
 | ancil_general_regrid_invert_mask_spiral_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_general_regrid_with_time_constraint_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_invert_mask_kdtree_split2 | succeeded | 
 | flake8 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split1 | succeeded | 
 | ancil_general_regrid_grid_to_variable_resolution_grid_split0 | succeeded | 
 | ancil_general_regrid_invert_mask_latitude_weighted_kdtree_split2 | succeeded | 
 | ancil_2anc_split1 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split1 | succeeded | 
 | ancil_general_regrid_grid_to_n48_namelist_split0 | succeeded | 
 | ancil_general_regrid_grid_to_grid_latitude_weighted_kdtree_split0 | succeeded | 
 | isort | succeeded | 
 | ancil_general_regrid_grid_to_grid_kdtree_split2 | succeeded | 
 | ancil_fill_n_merge_invert_mask_kdtree | succeeded | 
 | ancil_general_regrid_3d_to_3d_with_extrapolation_split1 | succeeded | 
 | ancil_fill_n_merge_land_cover_kdtree | succeeded | 
 | ancil_fill_n_merge_land_cover_spiral | succeeded | 
 | ancil_fill_n_merge_land_cover_latitude_weighted_kdtree | succeeded | 
 | rose_ana_2anc | succeeded | 
 | rose_ana_fill_n_merge | succeeded | 
 | rose_ana_general_regrid_kdtree | succeeded | 
 | rose_ana_general_regrid | succeeded | 
 | rose_ana_general_regrid_spiral | succeeded | 
 | rose_ana_general_regrid_latitude_weighted_kdtree | succeeded | 
 | linkcheck | succeeded | 

</div>
<br>
